### PR TITLE
Fix mail submission path and update thank you message

### DIFF
--- a/merci.html
+++ b/merci.html
@@ -6,7 +6,7 @@
   <title>Merci</title>
 </head>
 <body>
-  <h1>Merci pour votre demande !</h1>
-  <p>Nous reviendrons vers vous très bientôt.</p>
+  <h1>Le formulaire a bien été envoyé</h1>
+  <p>Un devis vous sera envoyé au plus tôt.</p>
 </body>
 </html>

--- a/sendmail.php
+++ b/sendmail.php
@@ -71,8 +71,8 @@ try {
     $mail->Body = $body;
 
     if ($mail->send()) {
-        header('Content-Type: application/json');
-        echo json_encode(['status' => 'success']);
+        header('Location: /merci.html');
+        exit;
     } else {
         header('Content-Type: application/json');
         echo json_encode(['status' => 'error', 'error' => $mail->ErrorInfo]);

--- a/src/components/ProductPicker.tsx
+++ b/src/components/ProductPicker.tsx
@@ -39,10 +39,10 @@ const ProductPicker = () => {
     <div id="product-picker" className="py-16">
       <div className="max-w-7xl mx-auto px-4">
         <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+          <h2 className="text-3xl md:text-4xl font-bold text-red-600 mb-4">
             Que souhaitez-vous assurer ?
           </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+          <p className="text-lg text-red-500 max-w-2xl mx-auto">
             Choisissez votre véhicule pour un devis personnalisé
           </p>
         </div>

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -87,7 +87,7 @@ const QuoteForm = () => {
           </div>
           
           {/* Form Content */}
-          <form ref={formRef} action="/api/mail.php" method="POST" className="p-8">
+          <form ref={formRef} action="/sendmail.php" method="POST" className="p-8">
             <input type="text" name="website" style={{ display: 'none' }} />
             <CurrentStepComponent />
             


### PR DESCRIPTION
## Summary
- send quote form to `/sendmail.php`
- redirect sendmail.php to thank-you page
- display a clearer confirmation message
- highlight vehicle choice header in bright colours

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68543446e6f8832780178a1dc5e31030