### PR TITLE
Reinstate red-green palette and remove unused contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,7 @@
     <title>Assurance permis suspendu, malussé ou résilié – Devis en 3 min | Assugeris</title>
     <meta name="description" content="Besoin d'une assurance auto ou moto après retrait de permis ? Assugeris trouve la meilleure offre. Service rapide, 20 ans d'expertise risques aggravés. Devis gratuit immédiat !" />
     
-    <!-- GOOGLE ADS GLOBAL TAG – TO BE REPLACED -->
-    <!-- Conversion event aw_lead goes here -->
+    <!-- GOOGLE TAG HEAD: coller ici les <script> du GTM -->
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,37 +15,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <form id="contact-form" style="margin-top:2rem">
-      <input type="text" name="name" placeholder="Prénom" required />
-      <input type="email" name="email" placeholder="Email" required />
-      <input type="text" name="subject" placeholder="Sujet" required />
-      <textarea name="message" placeholder="Message" required></textarea>
-      <button type="submit">Envoyer</button>
-    </form>
-    <div id="form-response"></div>
-    <script>
-      const form = document.getElementById('contact-form');
-      form?.addEventListener('submit', function (e) {
-        e.preventDefault();
-        fetch('sendmail.php', {
-          method: 'POST',
-          body: new FormData(form)
-        })
-          .then((r) => r.json())
-          .then((data) => {
-            const el = document.getElementById('form-response');
-            if (data.status === 'success') {
-              el.textContent = 'Message envoyé !';
-            } else {
-              el.textContent = data.error || 'Erreur';
-            }
-          })
-          .catch(() => {
-            const el = document.getElementById('form-response');
-            el.textContent = 'Erreur réseau';
-          });
-      });
-    </script>
+    <!-- GOOGLE TAG BODY: coller ici le noscript -->
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/sendmail.php
+++ b/sendmail.php
@@ -57,7 +57,7 @@ try {
     $mail->isHTML(true);
 
     $body = "<html><body style='font-family:Arial,sans-serif'>" .
-        "<div style='background:#a02328;color:#fff;padding:20px;text-align:center'>" .
+        "<div style='background:#E53935;color:#fff;padding:20px;text-align:center'>" .
         "<h2 style='margin:0'>Nouveau message de contact</h2></div>" .
         "<table style='width:100%;border-collapse:collapse;margin-top:15px'>" .
         "<tr><td style='padding:8px;border:1px solid #ddd'><b>Prénom</b></td><td style='padding:8px;border:1px solid #ddd'>" . $name . "</td></tr>" .

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -55,15 +55,15 @@ const FAQ = () => {
             >
               <button
                 onClick={() => toggleFAQ(index)}
-                className="w-full px-6 py-4 text-left flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-[#16a34a] focus:ring-offset-2 rounded-lg"
+                className="w-full px-6 py-4 text-left flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-[#43A047] focus:ring-offset-2 rounded-lg"
               >
                 <span className="text-lg font-semibold text-gray-900">
                   {faq.question}
                 </span>
                 {openIndex === index ? (
-                  <ChevronUp className="w-5 h-5 text-[#83191d] flex-shrink-0" />
+                  <ChevronUp className="w-5 h-5 text-[#E53935] flex-shrink-0" />
                 ) : (
-                  <ChevronDown className="w-5 h-5 text-[#83191d] flex-shrink-0" />
+                  <ChevronDown className="w-5 h-5 text-[#E53935] flex-shrink-0" />
                 )}
               </button>
               

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,7 +23,7 @@ const Header = () => {
             <button
               onClick={scrollToForm}
               data-gtag="cta-quote"
-              className="bg-[#16a34a] hover:bg-[#15803d] text-white px-4 py-2 md:px-6 md:py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl text-sm md:text-base"
+              className="bg-[#43A047] hover:bg-[#388E3C] text-white px-4 py-2 md:px-6 md:py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl text-sm md:text-base"
             >
               Commencer mon devis
             </button>
@@ -32,7 +32,7 @@ const Header = () => {
               href="https://www.assugeris-espace-assurances.fr/"
               target="_blank"
               rel="noopener noreferrer"
-              className="bg-[#16a34a] hover:bg-[#15803d] text-white px-4 py-2 md:px-6 md:py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl text-sm md:text-base"
+              className="bg-[#43A047] hover:bg-[#388E3C] text-white px-4 py-2 md:px-6 md:py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl text-sm md:text-base"
             >
               Plus d'informations
             </a>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -20,7 +20,7 @@ const Hero = () => {
       />
       
       {/* Gradient Overlay */}
-      <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/50 to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-r from-white/80 via-white/60 to-transparent" />
       
       {/* Content */}
       <div

--- a/src/components/LegalBand.tsx
+++ b/src/components/LegalBand.tsx
@@ -4,7 +4,7 @@ const LegalBand = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-[#83191d] text-white py-6">
+    <footer className="bg-[#E53935] text-white py-6">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex flex-col md:flex-row items-center justify-between space-y-4 md:space-y-0">
           <div className="flex items-center space-x-4">

--- a/src/components/ProductPicker.tsx
+++ b/src/components/ProductPicker.tsx
@@ -55,12 +55,12 @@ const ProductPicker = () => {
                 key={product.id}
                 onClick={() => handleProductSelect(product.id)}
                 className={`cursor-pointer bg-white rounded-xl p-8 shadow-lg transition-all duration-300 hover:shadow-xl hover:-translate-y-2 border-2 ${
-                  selectedProduct === product.id ? 'border-[#83191d]' : 'border-transparent'
+                  selectedProduct === product.id ? 'border-[#E53935]' : 'border-transparent'
                 }`}
               >
                 <div className="text-center">
                   <div className="mb-6 flex justify-center">
-                    <div className="bg-[#83191d] text-white p-4 rounded-full">
+                    <div className="bg-[#E53935] text-white p-4 rounded-full">
                       <Icon className="w-8 h-8" />
                     </div>
                   </div>

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -49,7 +49,7 @@ const QuoteForm = () => {
 
 
   return (
-    <section id="quote-form" className="py-16 bg-gradient-to-br from-[#83191d] to-[#a02328]">
+    <section id="quote-form" className="py-16 bg-gradient-to-br from-[#E53935] to-[#C62828]">
       <div className="max-w-4xl mx-auto px-4">
         <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
           {/* Header */}
@@ -64,21 +64,21 @@ const QuoteForm = () => {
                 <React.Fragment key={step.id}>
                   <div className="flex items-center flex-shrink-0">
                     <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
-                      currentStep >= step.id 
-                        ? 'bg-[#16a34a] text-white' 
+                      currentStep >= step.id
+                        ? 'bg-[#43A047] text-white'
                         : 'bg-gray-200 text-gray-600'
                     }`}>
                       {index + 1}
                     </div>
                     <span className={`ml-2 text-xs md:text-sm font-medium ${
-                      currentStep >= step.id ? 'text-[#16a34a]' : 'text-gray-500'
+                      currentStep >= step.id ? 'text-[#43A047]' : 'text-gray-500'
                     }`}>
                       {step.name}
                     </span>
                   </div>
                   {index < steps.length - 1 && (
                     <div className={`flex-1 h-0.5 min-w-[20px] ${
-                      currentStep > step.id ? 'bg-[#16a34a]' : 'bg-gray-200'
+                      currentStep > step.id ? 'bg-[#43A047]' : 'bg-gray-200'
                     }`} />
                   )}
                 </React.Fragment>
@@ -111,7 +111,7 @@ const QuoteForm = () => {
                 <button
                   type="button"
                   onClick={handleNext}
-                  className="flex items-center space-x-2 bg-[#16a34a] hover:bg-[#15803d] text-white px-6 py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl"
+                  className="flex items-center space-x-2 bg-[#43A047] hover:bg-[#388E3C] text-white px-6 py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl"
                 >
                   <span>Suivant</span>
                   <ArrowRight className="w-5 h-5" />
@@ -125,7 +125,7 @@ const QuoteForm = () => {
                   className={`flex items-center space-x-2 px-8 py-3 rounded-full font-semibold transition-all duration-300 shadow-lg hover:shadow-xl ${
                     isSubmitting 
                       ? 'bg-gray-400 cursor-not-allowed' 
-                      : 'bg-[#16a34a] hover:bg-[#15803d] text-white'
+                      : 'bg-[#43A047] hover:bg-[#388E3C] text-white'
                   }`}
                 >
                   <span>{isSubmitting ? 'Envoi en cours...' : 'Envoyer ma demande'}</span>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -125,7 +125,7 @@ const Testimonials = () => {
                 key={index}
                 onClick={() => setCurrentTestimonial(index)}
                 className={`w-3 h-3 rounded-full transition-all duration-300 ${
-                  index === currentTestimonial ? 'bg-[#83191d]' : 'bg-gray-300 hover:bg-gray-400'
+                  index === currentTestimonial ? 'bg-[#E53935]' : 'bg-gray-300 hover:bg-gray-400'
                 }`}
               />
             ))}
@@ -137,7 +137,7 @@ const Testimonials = () => {
           {keyWords.map((keyword, index) => (
             <span
               key={index}
-              className="bg-[#83191d] text-white px-4 py-2 rounded-full text-sm font-medium"
+              className="bg-[#E53935] text-white px-4 py-2 rounded-full text-sm font-medium"
             >
               {keyword}
             </span>

--- a/src/components/TopContactBar.tsx
+++ b/src/components/TopContactBar.tsx
@@ -3,7 +3,7 @@ import { Phone } from 'lucide-react';
 
 const TopContactBar = () => {
   return (
-    <div className="bg-[#83191d] text-white shadow-lg sticky top-0 z-50">
+    <div className="bg-[#E53935] text-white shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 py-2 md:py-3">
         <div className="flex items-center justify-between h-8 md:h-10">
           <span className="text-xs md:text-sm">
@@ -11,7 +11,7 @@ const TopContactBar = () => {
           </span>
           <a
             href="tel:0468057545"
-            className="bg-white text-[#83191d] px-2 py-1 md:px-3 md:py-2 rounded-full font-semibold transition-all duration-300 hover:bg-gray-100 inline-flex items-center space-x-1 md:space-x-2 text-xs md:text-sm"
+            className="bg-white text-[#E53935] px-2 py-1 md:px-3 md:py-2 rounded-full font-semibold transition-all duration-300 hover:bg-gray-100 inline-flex items-center space-x-1 md:space-x-2 text-xs md:text-sm"
           >
             <Phone className="w-3 h-3 md:w-4 md:h-4" />
             <span>04 68 05 75 45</span>

--- a/src/components/WhyUs.tsx
+++ b/src/components/WhyUs.tsx
@@ -71,7 +71,7 @@ const WhyUs = () => {
                 style={{ transitionDelay: `${index * 150}ms` }}
               >
                 <div className="mb-6 flex justify-center">
-                  <div className="bg-gradient-to-br from-[#83191d] to-[#a02328] text-white p-6 rounded-full shadow-lg group-hover:shadow-xl transition-all duration-300 group-hover:-translate-y-2 group-hover:scale-110">
+                  <div className="bg-gradient-to-br from-[#E53935] to-[#C62828] text-white p-6 rounded-full shadow-lg group-hover:shadow-xl transition-all duration-300 group-hover:-translate-y-2 group-hover:scale-110">
                     <Icon className="w-8 h-8" />
                   </div>
                 </div>

--- a/src/components/form/AccidentsStep.tsx
+++ b/src/components/form/AccidentsStep.tsx
@@ -61,7 +61,7 @@ const AccidentsStep = () => {
                   name={`accidentDate_${index}`}
                   value={accident.date || ''}
                   onChange={(e) => handleAccidentChange(index, 'date', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 />
               </div>
               
@@ -73,7 +73,7 @@ const AccidentsStep = () => {
                   name={`accidentNature_${index}`}
                   value={accident.nature || ''}
                   onChange={(e) => handleAccidentChange(index, 'nature', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 >
                   <option value="">Sélectionnez</option>
                   <option value="material">Matériel</option>
@@ -92,7 +92,7 @@ const AccidentsStep = () => {
                   name={`accidentResponsibility_${index}`}
                   value={accident.responsibility || ''}
                   onChange={(e) => handleAccidentChange(index, 'responsibility', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 >
                   <option value="">Sélectionnez</option>
                   <option value="0">0</option>
@@ -110,7 +110,7 @@ const AccidentsStep = () => {
                   value={accident.details || ''}
                   onChange={(e) => handleAccidentChange(index, 'details', e.target.value)}
                   rows={2}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                   placeholder="Circonstances, dégâts..."
                 />
               </div>
@@ -122,7 +122,7 @@ const AccidentsStep = () => {
           <button
             type="button"
             onClick={addAccident}
-            className="flex items-center space-x-2 text-[#16a34a] hover:text-[#15803d] transition-colors duration-300"
+            className="flex items-center space-x-2 text-[#43A047] hover:text-[#2E7D32] transition-colors duration-300"
           >
             <Plus className="w-5 h-5" />
             <span>Ajouter un sinistre</span>

--- a/src/components/form/ContactStep.tsx
+++ b/src/components/form/ContactStep.tsx
@@ -24,7 +24,7 @@ const ContactStep = () => {
             name="firstName"
             value={formData.contact?.firstName || ''}
             onChange={(e) => handleInputChange('firstName', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           />
         </div>
@@ -38,7 +38,7 @@ const ContactStep = () => {
             name="lastName"
             value={formData.contact?.lastName || ''}
             onChange={(e) => handleInputChange('lastName', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           />
         </div>
@@ -52,7 +52,7 @@ const ContactStep = () => {
             name="email"
             value={formData.contact?.email || ''}
             onChange={(e) => handleInputChange('email', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           />
         </div>
@@ -66,7 +66,7 @@ const ContactStep = () => {
             name="phone"
             value={formData.contact?.phone || ''}
             onChange={(e) => handleInputChange('phone', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           />
         </div>
@@ -81,7 +81,7 @@ const ContactStep = () => {
           value={formData.contact?.message || ''}
           onChange={(e) => handleInputChange('message', e.target.value)}
           rows={4}
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
           placeholder="Précisions sur votre situation, questions particulières..."
         />
       </div>

--- a/src/components/form/LicenseHistoryStep.tsx
+++ b/src/components/form/LicenseHistoryStep.tsx
@@ -54,7 +54,7 @@ const LicenseHistoryStep = () => {
                 name="autoLicenseDate"
                 value={formData.license?.autoLicenseDate || ''}
                 onChange={(e) => handleInputChange('license', 'autoLicenseDate', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               />
             </div>
             
@@ -70,7 +70,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.license?.autoInsured === 'yes'}
                     onChange={(e) => handleInputChange('license', 'autoInsured', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -81,7 +81,7 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.license?.autoInsured === 'no'}
                     onChange={(e) => handleInputChange('license', 'autoInsured', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
@@ -97,7 +97,7 @@ const LicenseHistoryStep = () => {
                 name="autoBonus"
                 value={formData.license?.autoBonus || ''}
                 onChange={(e) => handleInputChange('license', 'autoBonus', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 placeholder="Ex: 0.50"
               />
             </div>
@@ -111,7 +111,7 @@ const LicenseHistoryStep = () => {
                 name="autoTerminationDate"
                 value={formData.license?.autoTerminationDate || ''}
                 onChange={(e) => handleInputChange('license', 'autoTerminationDate', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               />
             </div>
             
@@ -123,7 +123,7 @@ const LicenseHistoryStep = () => {
                 name="autoTerminationReason"
                 value={formData.license?.autoTerminationReason || ''}
                 onChange={(e) => handleInputChange('license', 'autoTerminationReason', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               >
                 <option value="">Sélectionnez</option>
                 <option value="false-declaration">Fausse déclaration</option>
@@ -151,7 +151,7 @@ const LicenseHistoryStep = () => {
                 name="motoLicenseDate"
                 value={formData.license?.motoLicenseDate || ''}
                 onChange={(e) => handleInputChange('license', 'motoLicenseDate', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               />
             </div>
             
@@ -167,7 +167,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.license?.motoInsured === 'yes'}
                     onChange={(e) => handleInputChange('license', 'motoInsured', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -178,7 +178,7 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.license?.motoInsured === 'no'}
                     onChange={(e) => handleInputChange('license', 'motoInsured', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
@@ -197,7 +197,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.license?.motoUnder400Experience === 'yes'}
                     onChange={(e) => handleInputChange('license', 'motoUnder400Experience', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -208,7 +208,7 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.license?.motoUnder400Experience === 'no'}
                     onChange={(e) => handleInputChange('license', 'motoUnder400Experience', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
@@ -224,7 +224,7 @@ const LicenseHistoryStep = () => {
                 name="motoBonus"
                 value={formData.license?.motoBonus || ''}
                 onChange={(e) => handleInputChange('license', 'motoBonus', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 placeholder="Ex: 0.50"
               />
             </div>
@@ -238,7 +238,7 @@ const LicenseHistoryStep = () => {
                 name="motoTerminationDate"
                 value={formData.license?.motoTerminationDate || ''}
                 onChange={(e) => handleInputChange('license', 'motoTerminationDate', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               />
             </div>
             
@@ -250,7 +250,7 @@ const LicenseHistoryStep = () => {
                 name="motoTerminationReason"
                 value={formData.license?.motoTerminationReason || ''}
                 onChange={(e) => handleInputChange('license', 'motoTerminationReason', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               >
                 <option value="">Sélectionnez</option>
                 <option value="false-declaration">Fausse déclaration</option>
@@ -274,7 +274,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.license?.vehicleBridged === 'yes'}
                     onChange={(e) => handleInputChange('license', 'vehicleBridged', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -285,7 +285,7 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.license?.vehicleBridged === 'no'}
                     onChange={(e) => handleInputChange('license', 'vehicleBridged', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
@@ -315,7 +315,7 @@ const LicenseHistoryStep = () => {
                   value="yes"
                   checked={formData.sanctions?.alcoholDrugsSanction === 'yes'}
                   onChange={(e) => handleInputChange('sanctions', 'alcoholDrugsSanction', e.target.value)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span>Oui</span>
               </label>
@@ -326,14 +326,14 @@ const LicenseHistoryStep = () => {
                   value="no"
                   checked={formData.sanctions?.alcoholDrugsSanction === 'no'}
                   onChange={(e) => handleInputChange('sanctions', 'alcoholDrugsSanction', e.target.value)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span>Non</span>
               </label>
             </div>
             
             {formData.sanctions?.alcoholDrugsSanction === 'yes' && (
-              <div className="pl-4 border-l-2 border-[#16a34a] space-y-4">
+              <div className="pl-4 border-l-2 border-[#43A047] space-y-4">
                 <div className="grid md:grid-cols-2 gap-4">
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -344,7 +344,7 @@ const LicenseHistoryStep = () => {
                       name="lastInfractionDate"
                       value={formData.sanctions?.lastInfractionDate || ''}
                       onChange={(e) => handleInputChange('sanctions', 'lastInfractionDate', e.target.value)}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                     />
                   </div>
                   
@@ -357,7 +357,7 @@ const LicenseHistoryStep = () => {
                       name="airLevel"
                       value={formData.sanctions?.airLevel || ''}
                       onChange={(e) => handleInputChange('sanctions', 'airLevel', e.target.value)}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                       placeholder="Ex: 0.25"
                       step="0.01"
                     />
@@ -372,7 +372,7 @@ const LicenseHistoryStep = () => {
                       name="bloodLevel"
                       value={formData.sanctions?.bloodLevel || ''}
                       onChange={(e) => handleInputChange('sanctions', 'bloodLevel', e.target.value)}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                       placeholder="Ex: 0.5"
                       step="0.01"
                     />
@@ -390,7 +390,7 @@ const LicenseHistoryStep = () => {
                           value="yes"
                           checked={formData.sanctions?.accidentControl === 'yes'}
                           onChange={(e) => handleInputChange('sanctions', 'accidentControl', e.target.value)}
-                          className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                          className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                         />
                         <span>Oui</span>
                       </label>
@@ -401,7 +401,7 @@ const LicenseHistoryStep = () => {
                           value="no"
                           checked={formData.sanctions?.accidentControl === 'no'}
                           onChange={(e) => handleInputChange('sanctions', 'accidentControl', e.target.value)}
-                          className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                          className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                         />
                         <span>Non</span>
                       </label>
@@ -425,7 +425,7 @@ const LicenseHistoryStep = () => {
                   value="yes"
                   checked={formData.sanctions?.licenseSuspension === 'yes'}
                   onChange={(e) => handleInputChange('sanctions', 'licenseSuspension', e.target.value)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span>Oui</span>
               </label>
@@ -436,14 +436,14 @@ const LicenseHistoryStep = () => {
                   value="no"
                   checked={formData.sanctions?.licenseSuspension === 'no'}
                   onChange={(e) => handleInputChange('sanctions', 'licenseSuspension', e.target.value)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span>Non</span>
               </label>
             </div>
             
             {formData.sanctions?.licenseSuspension === 'yes' && (
-              <div className="pl-4 border-l-2 border-[#16a34a]">
+              <div className="pl-4 border-l-2 border-[#43A047]">
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Durée
                 </label>
@@ -451,7 +451,7 @@ const LicenseHistoryStep = () => {
                   name="suspensionDuration"
                   value={formData.sanctions?.suspensionDuration || ''}
                   onChange={(e) => handleInputChange('sanctions', 'suspensionDuration', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 >
                   <option value="">Sélectionnez</option>
                   <option value="less-6-months">&lt; 6 mois</option>
@@ -476,7 +476,7 @@ const LicenseHistoryStep = () => {
                   value="yes"
                   checked={formData.sanctions?.licenseCancellation === 'yes'}
                   onChange={(e) => handleInputChange('sanctions', 'licenseCancellation', e.target.value)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span>Oui</span>
               </label>
@@ -487,14 +487,14 @@ const LicenseHistoryStep = () => {
                   value="no"
                   checked={formData.sanctions?.licenseCancellation === 'no'}
                   onChange={(e) => handleInputChange('sanctions', 'licenseCancellation', e.target.value)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span>Non</span>
               </label>
             </div>
             
             {formData.sanctions?.licenseCancellation === 'yes' && (
-              <div className="pl-4 border-l-2 border-[#16a34a]">
+              <div className="pl-4 border-l-2 border-[#43A047]">
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Motif
                 </label>
@@ -502,7 +502,7 @@ const LicenseHistoryStep = () => {
                   name="cancellationReason"
                   value={formData.sanctions?.cancellationReason || ''}
                   onChange={(e) => handleInputChange('sanctions', 'cancellationReason', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 >
                   <option value="">Sélectionnez</option>
                   <option value="alcohol">Alcool au volant</option>
@@ -528,7 +528,7 @@ const LicenseHistoryStep = () => {
                 name="license1Date"
                 value={formData.sanctions?.license1Date || ''}
                 onChange={(e) => handleInputChange('sanctions', 'license1Date', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               />
             </div>
             
@@ -541,7 +541,7 @@ const LicenseHistoryStep = () => {
                 name="license2Date"
                 value={formData.sanctions?.license2Date || ''}
                 onChange={(e) => handleInputChange('sanctions', 'license2Date', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               />
             </div>
           </div>
@@ -560,7 +560,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.sanctions?.judgment === 'yes'}
                     onChange={(e) => handleInputChange('sanctions', 'judgment', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -571,7 +571,7 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.sanctions?.judgment === 'no'}
                     onChange={(e) => handleInputChange('sanctions', 'judgment', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
@@ -590,7 +590,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.sanctions?.hitAndRun === 'yes'}
                     onChange={(e) => handleInputChange('sanctions', 'hitAndRun', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -601,7 +601,7 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.sanctions?.hitAndRun === 'no'}
                     onChange={(e) => handleInputChange('sanctions', 'hitAndRun', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
@@ -620,7 +620,7 @@ const LicenseHistoryStep = () => {
                     value="yes"
                     checked={formData.sanctions?.otherConvictions === 'yes'}
                     onChange={(e) => handleInputChange('sanctions', 'otherConvictions', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Oui</span>
                 </label>
@@ -631,14 +631,14 @@ const LicenseHistoryStep = () => {
                     value="no"
                     checked={formData.sanctions?.otherConvictions === 'no'}
                     onChange={(e) => handleInputChange('sanctions', 'otherConvictions', e.target.value)}
-                    className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                    className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                   />
                   <span>Non</span>
                 </label>
               </div>
               
               {formData.sanctions?.otherConvictions === 'yes' && (
-                <div className="pl-4 border-l-2 border-[#16a34a]">
+                <div className="pl-4 border-l-2 border-[#43A047]">
                   <label className="block text-sm font-medium text-gray-700 mb-2">
                     Décrivez la situation
                   </label>
@@ -647,7 +647,7 @@ const LicenseHistoryStep = () => {
                     value={formData.sanctions?.otherConvictionsDetails || ''}
                     onChange={(e) => handleInputChange('sanctions', 'otherConvictionsDetails', e.target.value)}
                     rows={3}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                     placeholder="Décrivez les circonstances..."
                   />
                 </div>
@@ -668,7 +668,7 @@ const LicenseHistoryStep = () => {
                   name="drugsLastInfractionDate"
                   value={formData.sanctions?.drugsLastInfractionDate || ''}
                   onChange={(e) => handleInputChange('sanctions', 'drugsLastInfractionDate', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 />
               </div>
               
@@ -683,7 +683,7 @@ const LicenseHistoryStep = () => {
                         type="checkbox"
                         checked={(formData.sanctions?.substances || []).includes(substance)}
                         onChange={(e) => handleMultiSelectChange('sanctions', 'substances', substance, e.target.checked)}
-                        className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                        className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                       />
                       <span className="text-sm">{substance}</span>
                     </label>
@@ -700,7 +700,7 @@ const LicenseHistoryStep = () => {
                   name="drugsLevel"
                   value={formData.sanctions?.drugsLevel || ''}
                   onChange={(e) => handleInputChange('sanctions', 'drugsLevel', e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                   placeholder="Ex: 2.5"
                   step="0.1"
                 />
@@ -718,7 +718,7 @@ const LicenseHistoryStep = () => {
               value={formData.sanctions?.otherInfractions || ''}
               onChange={(e) => handleInputChange('sanctions', 'otherInfractions', e.target.value)}
               rows={3}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               placeholder="Décrivez les autres infractions..."
             />
           </div>

--- a/src/components/form/NeedStep.tsx
+++ b/src/components/form/NeedStep.tsx
@@ -40,7 +40,7 @@ const NeedStep = () => {
               name="vehicleLicensePlate"
               value={formData.need?.vehicleLicensePlate || ''}
               onChange={(e) => handleInputChange('vehicleLicensePlate', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               placeholder="Ex: AB-123-CD"
               required
             />
@@ -55,7 +55,7 @@ const NeedStep = () => {
               name="vehicleBrand"
               value={formData.need?.vehicleBrand || ''}
               onChange={(e) => handleInputChange('vehicleBrand', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               placeholder="Ex: Peugeot, Renault..."
             />
           </div>
@@ -69,7 +69,7 @@ const NeedStep = () => {
               name="vehicleModel"
               value={formData.need?.vehicleModel || ''}
               onChange={(e) => handleInputChange('vehicleModel', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               placeholder="Ex: 308, Clio..."
             />
           </div>
@@ -83,7 +83,7 @@ const NeedStep = () => {
               name="vehicleFinition"
               value={formData.need?.vehicleFinition || ''}
               onChange={(e) => handleInputChange('vehicleFinition', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
               placeholder={selectedProduct === 'car' ? 'Ex: Allure, GT Line...' : 'Ex: 125cc, 600cc...'}
             />
           </div>
@@ -97,7 +97,7 @@ const NeedStep = () => {
               name="vehicleFirstRegistration"
               value={formData.need?.vehicleFirstRegistration || ''}
               onChange={(e) => handleInputChange('vehicleFirstRegistration', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             />
           </div>
           
@@ -111,7 +111,7 @@ const NeedStep = () => {
                 name="vehicleFiscalPower"
                 value={formData.need?.vehicleFiscalPower || ''}
                 onChange={(e) => handleInputChange('vehicleFiscalPower', e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
                 placeholder="Ex: 7 CV"
               />
             </div>
@@ -125,7 +125,7 @@ const NeedStep = () => {
               name="vehicleFuel"
               value={formData.need?.vehicleFuel || ''}
               onChange={(e) => handleInputChange('vehicleFuel', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             >
               <option value="">Sélectionnez</option>
               <option value="gasoline">Essence</option>
@@ -148,7 +148,7 @@ const NeedStep = () => {
                   type="checkbox"
                   checked={(formData.need?.guarantees || []).includes(guarantee)}
                   onChange={(e) => handleMultiSelectChange('guarantees', guarantee, e.target.checked)}
-                  className="mr-2 text-[#16a34a] focus:ring-[#16a34a]"
+                  className="mr-2 text-[#43A047] focus:ring-[#43A047]"
                 />
                 <span className="text-sm">{guarantee}</span>
               </label>
@@ -166,7 +166,7 @@ const NeedStep = () => {
           name="insuranceNeed"
           value={formData.need?.insuranceNeed || ''}
           onChange={(e) => handleInputChange('insuranceNeed', e.target.value)}
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
           required
         >
           <option value="">Sélectionnez votre besoin</option>
@@ -184,7 +184,7 @@ const NeedStep = () => {
             name="gdprConsent"
             checked={formData.need?.gdprConsent || false}
             onChange={(e) => handleInputChange('gdprConsent', e.target.checked.toString())}
-            className="mt-1 h-4 w-4 text-[#16a34a] focus:ring-[#16a34a] border-gray-300 rounded"
+            className="mt-1 h-4 w-4 text-[#43A047] focus:ring-[#43A047] border-gray-300 rounded"
             required
           />
           <span className="text-sm text-gray-700">

--- a/src/components/form/SubscriberStep.tsx
+++ b/src/components/form/SubscriberStep.tsx
@@ -24,7 +24,7 @@ const SubscriberStep = () => {
             name="birthDate"
             value={formData.subscriber?.birthDate || ''}
             onChange={(e) => handleInputChange('birthDate', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           />
         </div>
@@ -37,7 +37,7 @@ const SubscriberStep = () => {
             name="profession"
             value={formData.subscriber?.profession || ''}
             onChange={(e) => handleInputChange('profession', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           >
             <option value="">Sélectionnez</option>
@@ -57,7 +57,7 @@ const SubscriberStep = () => {
             name="maritalStatus"
             value={formData.subscriber?.maritalStatus || ''}
             onChange={(e) => handleInputChange('maritalStatus', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             required
           >
             <option value="">Sélectionnez</option>
@@ -78,7 +78,7 @@ const SubscriberStep = () => {
             name="postalCode"
             value={formData.subscriber?.postalCode || ''}
             onChange={(e) => handleInputChange('postalCode', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             placeholder="Ex: 75001"
             required
           />
@@ -93,7 +93,7 @@ const SubscriberStep = () => {
             name="city"
             value={formData.subscriber?.city || ''}
             onChange={(e) => handleInputChange('city', e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#16a34a] focus:border-transparent transition-all duration-300"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#43A047] focus:border-transparent transition-all duration-300"
             placeholder="Ex: Paris, Lyon..."
             required
           />

--- a/src/index.css
+++ b/src/index.css
@@ -32,7 +32,7 @@ input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.1);
+  box-shadow: 0 0 0 3px rgba(67, 160, 71, 0.1);
 }
 
 /* Smooth transitions for all interactive elements */
@@ -53,12 +53,12 @@ textarea {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #83191d;
+  background: #E53935;
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #a02328;
+  background: #C62828;
 }
 
 /* Prose styles for better readability */
@@ -67,7 +67,7 @@ textarea {
 }
 
 .prose a {
-  color: #16a34a;
+  color: #43A047;
   text-decoration: none;
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- remove unused contact form from index
- add Google Tag placeholders in head and body
- switch theme colors to red `#E53935` and green `#43A047`
- update progress bars, buttons, and highlights

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855740896388327898f0f36fe54043d